### PR TITLE
Add CrawlerUserName to API endpoint for getting SpinComments for Spin

### DIFF
--- a/Spintrest-Backend/Models/SpinCommentModel.js
+++ b/Spintrest-Backend/Models/SpinCommentModel.js
@@ -5,6 +5,7 @@ const mapSpinComment = (spinComment) => {
         spinID: spinComment.spinid !== undefined ? spinComment.spinid : spinComment.spinID,
         spinCommentID: spinComment.spincommentid !== undefined ? spinComment.spincommentid : spinComment.spinCommentID,
         crawlerID: spinComment.crawlerid !== undefined ? spinComment.crawlerid : spinComment.crawlerID,
+        crawlerUserName: spinComment.crawlerusername !== undefined ? spinComment.crawlerusername : spinComment.crawlerUserName,
         spinCommentMessage: spinComment.spincommentmessage !== undefined ? spinComment.spincommentmessage : spinComment.spinCommentMessage,
         spinCommentTimestamp: spinComment.spincommenttimestamp !== undefined ? spinComment.spincommenttimestamp : spinComment.spinCommentTimestamp,
         spinCommentIsDeleted: spinComment.spincommentisdeleted !== undefined ? spinComment.spincommentisdeleted : spinComment.spinCommentIsDeleted,

--- a/Spintrest-Backend/Repositories/ComplexRepository.js
+++ b/Spintrest-Backend/Repositories/ComplexRepository.js
@@ -43,17 +43,19 @@ const getCommentsForSpin = async (spinID) => {
     const result = await databaseContext.query(
         `select
             sc.spinCommentID,
-                min(sc.crawlerID) as crawlerID,
-                min(sc.spinID) as spinID,
-                min(sc.spinCommentMessage) as spinCommentMessage,
-                min(sc.spinCommentTimestamp) as spinCommentTimestamp,
-                bool_and(sc.spinCommentIsDeleted) as spinCommentIsDeleted,
-                coalesce(count(c.crawlerID), 0) as spinCommentLikeCount
+            min(sc.crawlerID) as crawlerID,
+            min(uc.crawlerUserName) as crawlerUserName,
+            min(sc.spinID) as spinID,
+            min(sc.spinCommentMessage) as spinCommentMessage,
+            min(sc.spinCommentTimestamp) as spinCommentTimestamp,
+            bool_and(sc.spinCommentIsDeleted) as spinCommentIsDeleted,
+            coalesce(count(c.crawlerID), 0) as spinCommentLikeCount
         from
             SpinComment as sc
             inner join Spin as s on s.spinID = sc.spinID
             left join CommentLikes as cl on cl.spinCommentID = sc.spinCommentID
             left join Crawler as c on cl.crawlerID = c.crawlerID
+            inner join Crawler as uc on uc.crawlerID = sc.crawlerID
         where
             sc.spinCommentIsDeleted = false and
             s.spinIsDeleted = false and


### PR DESCRIPTION
- Updated `getCommentsForSpin` to also return username.
- the crawlerUserName will come in every SpinComment call, but who cares.